### PR TITLE
Add biweek number computation and update version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,14 @@
 [project]
 name = "calx-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "A CLI tool for displaying calendar information with terminal graphics"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = ["rich>=14.0.0", "typer>=0.15.2"]
 
-
 [project.scripts]
 calx = "calx.cli:app"
-
-BDE8-620C
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = ["rich>=14.0.0", "typer>=0.15.2"]
 [project.scripts]
 calx = "calx.cli:app"
 
+BDE8-620C
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/calx/calendar_views.py
+++ b/src/calx/calendar_views.py
@@ -118,7 +118,7 @@ def render_month_calendar(
                     week_num = compute_week_number(day, first_day, min_days)
                     break
             row.append(
-                Text(str(week_num) if week_num is not None else "", style="dim yellow")
+                Text(f"W{week_num}" if week_num is not None else "", style="dim yellow")
             )
 
         for day in week:

--- a/src/calx/calendar_views.py
+++ b/src/calx/calendar_views.py
@@ -63,6 +63,11 @@ def compute_week_number(d: date, first_day: int = 1, min_days: int = 4) -> int:
     return week
 
 
+def compute_biweek_number(week: int) -> int:
+    """Compute biweek number from a week number (for invoicing periods)."""
+    return (week + 1) // 2
+
+
 def render_month_calendar(
     year: int,
     month: int,
@@ -91,19 +96,23 @@ def render_month_calendar(
         table.add_column(justify="right", style="dim")
     for _ in range(7):
         table.add_column(justify="right", width=2)
+    if show_week_numbers:
+        table.add_column(justify="right", style="dim")
 
     day_names = get_day_names(first_day)
     header = [Text(d, style="bold cyan") for d in day_names]
     if show_week_numbers:
-        table.add_row("", *header)
+        table.add_row("", *header, "")
     else:
         table.add_row(*header)
 
+    seen_biweeks: set[int] = set()
+
     for week in weeks:
         row: list[Text | str] = []
+        week_num = None
 
         if show_week_numbers:
-            week_num = None
             for day in week:
                 if day.month == month:
                     week_num = compute_week_number(day, first_day, min_days)
@@ -119,6 +128,16 @@ def render_month_calendar(
                 row.append(Text(str(day.day), style="bold reverse"))
             else:
                 row.append(Text(str(day.day)))
+
+        if show_week_numbers and week_num is not None:
+            bw = compute_biweek_number(week_num)
+            if bw not in seen_biweeks:
+                row.append(Text(f"B{bw}", style="dim magenta"))
+                seen_biweeks.add(bw)
+            else:
+                row.append("")
+        elif show_week_numbers:
+            row.append("")
 
         table.add_row(*row)
 

--- a/src/calx/cli.py
+++ b/src/calx/cli.py
@@ -9,6 +9,7 @@ from rich.panel import Panel
 from rich import box
 
 from calx.calendar_views import (
+    compute_biweek_number,
     compute_week_number,
     render_month_calendar,
     render_three_months,
@@ -50,7 +51,10 @@ def create_info_table(first_day: int = 1, min_days: int = 4) -> Table:
     table.add_column("Property", style="cyan")
     table.add_column("Value", style="green")
 
+    biweek = compute_biweek_number(week)
+
     table.add_row("Week", str(week))
+    table.add_row("Biweek", str(biweek))
     table.add_row("Year", str(today.year))
     table.add_row("Day", today.strftime("%A"))
     table.add_row("Day of Year", str(day_of_year))
@@ -90,6 +94,15 @@ def display_default_view(first_day: int = 1, min_days: int = 4):
     console.print(layout)
 
 
+def version_callback(value: bool):
+    """Print version and exit."""
+    if value:
+        from calx import __version__
+
+        console.print(f"calx {__version__}")
+        raise typer.Exit()
+
+
 def resolve_shortcut_format(
     simple_sunday: bool,
     iso_sunday: bool,
@@ -119,6 +132,14 @@ def resolve_shortcut_format(
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "-v",
+        "--version",
+        help="Show version and exit",
+        callback=version_callback,
+        is_eager=True,
+    ),
     month: bool = typer.Option(
         False, "-m", "--month", help="Show 3 months (previous, current, next)"
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "calx-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Introduce biweek number computation for invoicing periods and integrate it into the calendar display. Format the week number with a prefix 'W' in the month calendar. Update the project version to 0.3.0 in the configuration files.